### PR TITLE
fix typeguard warnings in StructRef tests

### DIFF
--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -283,6 +283,7 @@ class TestStructRefCaching(MemoryLeakMixin, TestCase):
         self._cache_override = override_config('CACHE_DIR', self._cache_dir)
         self._cache_override.__enter__()
         warnings.simplefilter("error")
+        warnings.filterwarnings(action="ignore", module="typeguard")
 
     def tearDown(self):
         self._cache_override.__exit__(None, None, None)


### PR DESCRIPTION
This adresses a latent error in in the StructRef tests that only
manifests when running under typeguard.

```
[2021-03-03 08:34:48,491] {docker_operator.py:262} INFO - ======================================================================
[2021-03-03 08:34:48,491] {docker_operator.py:262} INFO - ERROR: test_structref_caching (numba.tests.test_struct_ref.TestStructRefCaching)
[2021-03-03 08:34:48,491] {docker_operator.py:262} INFO - ----------------------------------------------------------------------
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - Traceback (most recent call last):
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - File "/src/numba/tests/test_struct_ref.py", line 318, in test_structref_caching
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - check(cached=False)
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - File "/src/numba/tests/test_struct_ref.py", line 306, in check
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - st = check_make(vs, ctr)
[2021-03-03 08:34:48,492] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 440, in _compile_for_args
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - raise e
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 373, in _compile_for_args
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - return_val = self.compile(tuple(argtypes))
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 911, in compile
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - cres = self._compiler.compile(args, return_type)
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 80, in compile
[2021-03-03 08:34:48,493] {docker_operator.py:262} INFO - status, retval = self._compile_cached(args, return_type)
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 94, in _compile_cached
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - retval = self._compile_core(args, return_type)
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - File "/src/numba/core/dispatcher.py", line 107, in _compile_core
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - cres = compiler.compile_extra(self.targetdescr.typing_context,
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - File "/src/numba/core/compiler.py", line 608, in compile_extra
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - return pipeline.compile_extra(func)
[2021-03-03 08:34:48,494] {docker_operator.py:262} INFO - File "/src/numba/core/compiler.py", line 354, in compile_extra
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - return self._compile_bytecode()
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - File "/src/numba/core/compiler.py", line 416, in _compile_bytecode
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - return self._compile_core()
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - File "/src/numba/core/compiler.py", line 396, in _compile_core
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - raise e
[2021-03-03 08:34:48,495] {docker_operator.py:262} INFO - File "/src/numba/core/compiler.py", line 387, in _compile_core
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - pm.run(self.state)
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - File "/src/numba/core/compiler_machinery.py", line 339, in run
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - raise patched_exception
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - File "/src/numba/core/compiler_machinery.py", line 330, in run
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - self._runPass(idx, pass_inst, state)
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - File "/src/numba/core/compiler_lock.py", line 35, in _acquire_compile_lock
[2021-03-03 08:34:48,496] {docker_operator.py:262} INFO - return func(*args, **kwargs)
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - File "/src/numba/core/compiler_machinery.py", line 289, in _runPass
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - mutated |= check(pss.run_pass, internal_state)
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - File "/src/numba/core/compiler_machinery.py", line 262, in check
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - mangled = func(compiler_state)
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - File "/src/numba/core/typed_passes.py", line 393, in run_pass
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - lower.create_cpython_wrapper(flags.release_gil)
[2021-03-03 08:34:48,497] {docker_operator.py:262} INFO - File "/src/numba/core/lowering.py", line 242, in create_cpython_wrapper
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - self.context.create_cpython_wrapper(self.library, self.fndesc,
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - File "/src/numba/core/cpu.py", line 162, in create_cpython_wrapper
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - builder.build()
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - File "/src/numba/core/callwrapper.py", line 122, in build
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - self.build_wrapper(api, builder, closure, args, kws)
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - File "/src/numba/core/callwrapper.py", line 155, in build_wrapper
[2021-03-03 08:34:48,498] {docker_operator.py:262} INFO - val = cleanup_manager.add_arg(builder.load(obj), ty)
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - File "/src/numba/core/callwrapper.py", line 30, in add_arg
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - native = self.api.to_native_value(ty, obj)
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - File "/src/numba/core/pythonapi.py", line 1390, in to_native_value
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - return impl(typ, obj, c)
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - File "/src/numba/core/boxing.py", line 445, in unbox_array
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - nativearycls = c.context.make_array(typ)
[2021-03-03 08:34:48,499] {docker_operator.py:262} INFO - File "/src/numba/core/base.py", line 1001, in make_array
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - return arrayobj.make_array(typ)
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - File "/src/numba/np/arrayobj.py", line 68, in make_array
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - class ArrayStruct(base):
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - File "/opt/conda/envs/testenv_cdb4dfe6-77d1-4e76-bdad-0d927a493a21/lib/python3.8/site-packages/typeguard/__init__.py", line 890, in typechecked
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - kwargs[name] = typechecked(
[2021-03-03 08:34:48,500] {docker_operator.py:262} INFO - File "/opt/conda/envs/testenv_cdb4dfe6-77d1-4e76-bdad-0d927a493a21/lib/python3.8/site-packages/typeguard/__init__.py", line 906, in typechecked
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO - warn('no type annotations present -- not typechecking {}'.format(function_name(func)))
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO - UserWarning: Failed in nopython mode pipeline (step: native lowering)
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO - no type annotations present -- not typechecking numba.np.arrayobj.make_array.<locals>.ArrayStruct.shape
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO -
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO - ----------------------------------------------------------------------
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO - Ran 10343 tests in 1559.663s
[2021-03-03 08:34:48,501] {docker_operator.py:262} INFO -
[2021-03-03 08:34:48,502] {docker_operator.py:262} INFO - FAILED (errors=1, skipped=1072, expected failures=12)
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
